### PR TITLE
feat: Update Nix package channel to 25.05

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -7,7 +7,7 @@ assignees: aglorei
 
 ---
 <!-- markdownlint-disable MD013 -->
-## Is your feature request related to a problem? Please describe
+## Describe the problem
 
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
@@ -19,6 +19,6 @@ A clear and concise description of what you want to happen.
 
 A clear and concise description of any alternative solutions or features you've considered.
 
-## Additional context
+## Provide additional context
 
 Add any other context or screenshots about the feature request here.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+---
+name: build
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: 0 6 * * 3
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: pip install --user yamllint
+
+      - run: yamllint --format github --strict .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+---
+name: deploy
+
+on:
+  workflow_run:
+    branches:
+      - main
+    types:
+      - completed
+    workflows:
+      - build
+
+run-name: ${{ github.event.workflow_run.display_title }}
+
+jobs:
+  release-please:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: release
+        uses: googleapis/release-please-action@v4
+        with:
+          release-type: simple

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  quoted-strings:
+    quote-type: any
+    required: only-when-needed
+    extra-required: []
+    extra-allowed: []
+    allow-quoted-quotes: false
+    check-keys: false
+  truthy:
+    allowed-values: ["true", "false", "on"]
+    check-keys: true

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ homeConfigurations = {
 Apply the home configuration with a username and host combination.
 
 ```sh
-nix run home-manager/release-24.11 -- switch --flake .#$(whoami)@$(hostname -s)
+nix run home-manager/release-25.05 -- switch --flake .#$(whoami)@$(hostname -s)
 ```
 
 ## Acknowledgements

--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1753549186,
+        "narHash": "sha256-Znl7rzuxKg/Mdm6AhimcKynM7V3YeNDIcLjBuoBcmNs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "17f6bd177404d6d43017595c5264756764444ab8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,32 +7,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688870,
-        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
+        "lastModified": 1753592768,
+        "narHash": "sha256-oV695RvbAE4+R9pcsT9shmp6zE/+IZe6evHWX63f2Qg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5f1f641b289553927b3801580598d200a501863",
+        "rev": "fc3add429f21450359369af74c2375cb34a2d204",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1753489912,
+        "narHash": "sha256-uDCFHeXdRIgJpYmtcUxGEsZ+hYlLPBhR83fdU+vbC1s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "13e8d35b7d6028b7198f8186bc0347c6abaa2701",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
   description = "Aglorei's Home Configuration";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
-    home-manager.url = "github:nix-community/home-manager/release-24.11";
+    home-manager.url = "github:nix-community/home-manager/release-25.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/home/aglorei/global/default.nix
+++ b/home/aglorei/global/default.nix
@@ -25,7 +25,7 @@
 
   services.gpg-agent = {
     enable = true;
-    pinentryPackage = pkgs.pinentry-curses;
+    pinentry.package = pkgs.pinentry-curses;
   };
 
   # SCM

--- a/home/aglorei/macbookpro.nix
+++ b/home/aglorei/macbookpro.nix
@@ -5,5 +5,5 @@
   imports = [./global];
 
   home.homeDirectory = "/Users/${config.home.username}";
-  home.stateVersion = "24.11";
+  home.stateVersion = "25.05";
 }

--- a/home/aglorei/mikasa.nix
+++ b/home/aglorei/mikasa.nix
@@ -5,5 +5,5 @@
   imports = [./global];
 
   home.homeDirectory = "/home/${config.home.username}";
-  home.stateVersion = "24.11";
+  home.stateVersion = "25.05";
 }

--- a/home/tienlong.pham/global/default.nix
+++ b/home/tienlong.pham/global/default.nix
@@ -22,7 +22,7 @@
 
   services.gpg-agent = {
     enable = true;
-    pinentryPackage = pkgs.pinentry-curses;
+    pinentry.package = pkgs.pinentry-curses;
   };
 
   # SCM

--- a/home/tienlong.pham/j2wnhywdqd.nix
+++ b/home/tienlong.pham/j2wnhywdqd.nix
@@ -1,5 +1,5 @@
 {pkgs, ...}: {
   imports = [./global];
 
-  home.stateVersion = "24.11";
+  home.stateVersion = "25.05";
 }

--- a/modules/home-manager/commons.nix
+++ b/modules/home-manager/commons.nix
@@ -28,11 +28,7 @@
     pkgs.neovim
 
     # Fonts
-    (pkgs.nerdfonts.override {
-      fonts = [
-        "Mononoki"
-      ];
-    })
+    pkgs.nerd-fonts.mononoki
 
     # Network
     pkgs.arp-scan


### PR DESCRIPTION
Fixes #22

chore: Update default issue template for consistency
ci: Initialize yamllint configuration
ci: Manage releases with release-please
fix(25.05): Rename services.gpg-agent.pinentryPackage to services.gpg-agent.pinentry.package
fix(25.05): Separate nerd font packages under the namespace nerd-fonts
